### PR TITLE
Fixes broken github link

### DIFF
--- a/window-menu-applet/dialog.ui
+++ b/window-menu-applet/dialog.ui
@@ -10,7 +10,7 @@
     <property name="program_name">Mate Window Applets - Window Menu</property>
     <property name="version">@VERSION@</property>
     <property name="copyright" translatable="yes">Copyright © 2017 Ivalin Radulov</property>
-    <property name="website">https://github.com/IKRadulov/mate-window-applets</property>
+    <property name="website">https://github.com/ubuntu-mate/mate-window-applets</property>
     <property name="logo_icon_name"/>
     <property name="license_type">gpl-3-0</property>
     <child internal-child="vbox">


### PR DESCRIPTION
The menu applet contained a link to the old repo that's been deleted. Since it now 404's I've changed it to point at the fork owned by ubuntu-mate instead.