### PR TITLE
Ignore dock and desktop windows

### DIFF
--- a/window-buttons-applet/window-buttons-applet.vala
+++ b/window-buttons-applet/window-buttons-applet.vala
@@ -218,13 +218,17 @@ namespace WindowButtonsApplet{
 
 		private Wnck.Window get_current_window(){
 			Wnck.Window* win = null;
+			Wnck.WindowType window_type;
 			string behaviour = gsettings.get_string("behaviour");
 
 			switch(behaviour){
 				case "active-always":
 					win = Wnck.Screen.get_default().get_active_window();
-					if(win != null && win->get_class_instance_name() == "desktop_window")
-						win = null;
+					if(win != null){
+						window_type = win->get_window_type();
+						if(window_type == Wnck.WindowType.DESKTOP || window_type == Wnck.WindowType.DOCK)
+							win = null;
+					}
 				break;
 				case "active-maximized":
 					win = Wnck.Screen.get_default().get_active_window();

--- a/window-menu-applet/window-menu-applet.vala
+++ b/window-menu-applet/window-menu-applet.vala
@@ -76,13 +76,17 @@ namespace WindowMenuApplet{
 
 	private Wnck.Window get_current_window(){
 		Wnck.Window* win = null;
+		Wnck.WindowType window_type;
 		string behaviour = gsettings.get_string("behaviour");
 
 		switch(behaviour){
 			case "active-always":
 				win = Wnck.Screen.get_default().get_active_window();
-				if(win != null && win->get_class_instance_name() == "desktop_window")
-					win = null;
+				if(win != null){
+					window_type = win->get_window_type();
+					if(window_type == Wnck.WindowType.DESKTOP || window_type == Wnck.WindowType.DOCK)
+						win = null;
+				}
 			break;
 			case "active-maximized":
 				win = Wnck.Screen.get_default().get_active_window();

--- a/window-title-applet/window-title-applet.vala
+++ b/window-title-applet/window-title-applet.vala
@@ -59,13 +59,17 @@ namespace WindowTitleApplet{
 
 	private Wnck.Window get_current_window(){
 		Wnck.Window* win = null;
+		Wnck.WindowType window_type;
 		string behaviour = gsettings.get_string("behaviour");
 
 		switch(behaviour){
 			case "active-always":
 				win = Wnck.Screen.get_default().get_active_window();
-				if(win != null && win->get_class_instance_name() == "desktop_window")
-					win = null;
+				if(win != null){
+					window_type = win->get_window_type();
+					if(window_type == Wnck.WindowType.DESKTOP || window_type == Wnck.WindowType.DOCK)
+						win = null;
+				}
 			break;
 			case "active-maximized":
 				win = Wnck.Screen.get_default().get_active_window();


### PR DESCRIPTION
Fixed logic that determines whether the window in focus is the desktop
by using the window type from WNCK. Also added the Dock type to avoid
showing mate-menu and mate-panel, since activating them has undefined
behavior.