### PR TITLE
Add support for multiple monitors and workspaces

### DIFF
--- a/window-buttons-applet/window-buttons-applet.vala
+++ b/window-buttons-applet/window-buttons-applet.vala
@@ -239,7 +239,7 @@ namespace WindowButtonsApplet{
 				if(win->is_minimized())
 					continue;
 
-				if(!win->is_on_workspace(active_workspace))
+				if(!win->is_in_viewport(active_workspace))
 					continue;
 
 				if(monitor != get_monitor_at_window(win))

--- a/window-buttons-applet/window-buttons-applet.vala
+++ b/window-buttons-applet/window-buttons-applet.vala
@@ -12,8 +12,10 @@ namespace WindowButtonsApplet{
 			bool maximize ;
 		}
 
+		public Gdk.Monitor monitor;
 		private Wnck.Window* window = null;
 		private Wnck.Window *active_window = null;
+		private Gdk.Monitor active_window_monitor;
 
 		public GLib.Settings gsettings = new GLib.Settings("org.mate.window-applets.window-buttons");
 		public GLib.Settings marco_gsettings = new GLib.Settings("org.mate.Marco.general");
@@ -91,9 +93,10 @@ namespace WindowButtonsApplet{
 				window->state_changed.disconnect(reload);
 			}
 
-			if(active_window != null)
+			if(active_window != null){
 				active_window->state_changed.disconnect(reload);
-
+				active_window->geometry_changed.disconnect(detect_monitor_change);
+			}
 
 			window = get_current_window();
 
@@ -105,11 +108,15 @@ namespace WindowButtonsApplet{
 				window->state_changed.connect(reload);
 			}
 
-			// When active window is not the controlled window (because it is unmaximized),
-			// we need to watch its state as well
 			active_window = Wnck.Screen.get_default().get_active_window();
-			if(active_window != null && active_window != window)
-				active_window->state_changed.connect(reload);
+			if(active_window != null){
+				// When active window is not the controlled window (because it is unmaximized),
+				// we need to watch its state as well
+				if(active_window != window)
+					active_window->state_changed.connect(reload);
+
+				active_window->geometry_changed.connect(detect_monitor_change);
+			}
 		}
 
 		public void change_layout(){
@@ -216,38 +223,62 @@ namespace WindowButtonsApplet{
 				Wnck.Screen.get_default().window_closed.connect( reload );
 		}
 
-		private Wnck.Window get_current_window(){
-			Wnck.Window* win = null;
+		private Wnck.Window? get_current_window(){
 			Wnck.WindowType window_type;
 			string behaviour = gsettings.get_string("behaviour");
+			Wnck.Workspace active_workspace = Wnck.Screen.get_default().get_active_workspace();
 
-			switch(behaviour){
-				case "active-always":
-					win = Wnck.Screen.get_default().get_active_window();
-					if(win != null){
-						window_type = win->get_window_type();
-						if(window_type == Wnck.WindowType.DESKTOP || window_type == Wnck.WindowType.DOCK)
-							win = null;
-					}
-				break;
-				case "active-maximized":
-					win = Wnck.Screen.get_default().get_active_window();
-					if(win != null && !win->is_maximized())
-						win = null;
-				break;
-				case "topmost-maximized":
-					List<weak Wnck.Window> windows = Wnck.Screen.get_default().get_windows_stacked().copy();
-					windows.reverse();
-					foreach(Wnck.Window* w in windows) {
-						if(w->is_maximized() && !w->is_minimized()){
-							win = w;
-							break;
-						}
-					}
-				break;
+			List<weak Wnck.Window> windows = Wnck.Screen.get_default().get_windows_stacked().copy();
+			windows.reverse();
+
+			foreach(Wnck.Window* win in windows) {
+				window_type = win->get_window_type();
+				if(window_type == Wnck.WindowType.DESKTOP || window_type == Wnck.WindowType.DOCK)
+					continue;
+
+				if(win->is_minimized())
+					continue;
+
+				if(!win->is_on_workspace(active_workspace))
+					continue;
+
+				if(monitor != get_monitor_at_window(win))
+					continue;
+
+				switch(behaviour){
+					case "active-always":
+						return win;
+
+					case "active-maximized":
+						if(win->is_maximized())
+							return win;
+						else
+							return null;
+
+					case "topmost-maximized":
+						if(win->is_maximized())
+							return win;
+					break;
+				}
 			}
 
-			return win;
+			return null;
+		}
+
+		private Gdk.Monitor? get_monitor_at_window(Wnck.Window *win){
+			int x, y, w, h;
+
+			win->get_client_window_geometry(out x, out y, out w, out h);
+
+			return Gdk.Display.get_default().get_monitor_at_point(x + w/2, y + h/2);
+		}
+
+		private void detect_monitor_change(){
+			Gdk.Monitor mon = get_monitor_at_window(active_window);
+			if(mon != active_window_monitor){
+				active_window_monitor = mon;
+				reload();
+			}
 		}
 	}
 
@@ -272,6 +303,8 @@ namespace WindowButtonsApplet{
 		Gtk.Window about = builder.get_object("About") as Gtk.Window;
 
 		var widget_container = new ButtonsApplet(Gtk.Orientation.HORIZONTAL, applet.get_style_context());
+
+		widget_container.monitor = applet.get_parent_window().get_screen().get_display().get_monitor_at_window(applet.get_parent_window());
 
 		widget_container.show();
 		widget_container.change_orient(applet.get_orient());

--- a/window-menu-applet/window-menu-applet.vala
+++ b/window-menu-applet/window-menu-applet.vala
@@ -101,7 +101,7 @@ namespace WindowMenuApplet{
 				if(win->is_minimized())
 					continue;
 
-				if(!win->is_on_workspace(active_workspace))
+				if(!win->is_in_viewport(active_workspace))
 					continue;
 
 				if(monitor != get_monitor_at_window(win))

--- a/window-menu-applet/window-menu-applet.vala
+++ b/window-menu-applet/window-menu-applet.vala
@@ -2,121 +2,120 @@ using WindowWidgets;
 
 namespace WindowMenuApplet{
 
-	WindowWidgets.WindowMenuButton button;
-	Wnck.Window *window;
-	Wnck.Window *active_window;
+	class WindowMenu {
+		public WindowWidgets.WindowMenuButton button;
+		private Wnck.Window *window;
+		private Wnck.Window *active_window;
 
-	GLib.Settings gsettings;
+		public GLib.Settings gsettings = new GLib.Settings("org.mate.window-applets.window-menu");
 
-	public void reload(){
-
-		// Disconnect signals from old window
-		if(window != null){
-			window->icon_changed.disconnect(button.icon_set);
-			window->actions_changed.disconnect(button.menu_set);
-			window->state_changed.disconnect(reload);
+		public WindowMenu(){
+			button = new WindowMenuButton();
 		}
 
-		if(active_window != null)
-			active_window->state_changed.disconnect(reload);
+		public void reload(){
+
+			// Disconnect signals from old window
+			if(window != null){
+				window->icon_changed.disconnect(button.icon_set);
+				window->actions_changed.disconnect(button.menu_set);
+				window->state_changed.disconnect(reload);
+			}
+
+			if(active_window != null)
+				active_window->state_changed.disconnect(reload);
 
 
-		window = get_current_window();
+			window = get_current_window();
 
-		button.window = window;
+			button.window = window;
 
-		button.icon_set();
-		button.menu_set();
+			button.icon_set();
+			button.menu_set();
 
-		// Watch for changes to new controlled window
-		if(window != null){
-			window->icon_changed.connect(button.icon_set);
-			window->actions_changed.connect(button.menu_set);
-			window->state_changed.connect(reload);
+			// Watch for changes to new controlled window
+			if(window != null){
+				window->icon_changed.connect(button.icon_set);
+				window->actions_changed.connect(button.menu_set);
+				window->state_changed.connect(reload);
+			}
+
+			// When active window is not the controlled window (because it is unmaximized),
+			// we need to watch its state as well
+			active_window = Wnck.Screen.get_default().get_active_window();
+			if(active_window != null && active_window != window)
+				active_window->state_changed.connect(reload);
 		}
 
-		// When active window is not the controlled window (because it is unmaximized),
-		// we need to watch its state as well
-		active_window = Wnck.Screen.get_default().get_active_window();
-		if(active_window != null && active_window != window)
-			active_window->state_changed.connect(reload);
-	}
+		public void change_orient(MatePanel.Applet applet){
+			MatePanel.AppletOrient orient = applet.get_orient();
+			switch(orient){
+				case MatePanel.AppletOrient.UP:
+					button.set_direction(Gtk.ArrowType.DOWN);
+					break;
+				case MatePanel.AppletOrient.DOWN:
+					button.set_direction(Gtk.ArrowType.UP);
+					break;
+				case MatePanel.AppletOrient.LEFT:
+					button.set_direction(Gtk.ArrowType.RIGHT);
+					break;
+				case MatePanel.AppletOrient.RIGHT:
+					button.set_direction(Gtk.ArrowType.LEFT);
+					break;
+				default:
+					break;
+			}
 
-	public void change_orient(MatePanel.Applet applet){
-		MatePanel.AppletOrient orient = applet.get_orient();
-		switch(orient){
-			case MatePanel.AppletOrient.UP:
-				button.set_direction(Gtk.ArrowType.DOWN);
-				break;
-			case MatePanel.AppletOrient.DOWN:
-				button.set_direction(Gtk.ArrowType.UP);
-				break;
-			case MatePanel.AppletOrient.LEFT:
-				button.set_direction(Gtk.ArrowType.RIGHT);
-				break;
-			case MatePanel.AppletOrient.RIGHT:
-				button.set_direction(Gtk.ArrowType.LEFT);
-				break;
-			default:
-				break;
 		}
 
-		reload();
+		public void change_behaviour(){
+			string behaviour = gsettings.get_string("behaviour");
 
-	}
+			Wnck.Screen.get_default().window_closed.disconnect( reload );
 
-	public void change_behaviour(){
-		string behaviour = gsettings.get_string("behaviour");
+			if(behaviour == "topmost-maximized")
+				Wnck.Screen.get_default().window_closed.connect( reload );
+		}
 
-		Wnck.Screen.get_default().window_closed.disconnect( reload );
+		private Wnck.Window get_current_window(){
+			Wnck.Window* win = null;
+			Wnck.WindowType window_type;
+			string behaviour = gsettings.get_string("behaviour");
 
-		if(behaviour == "topmost-maximized")
-			Wnck.Screen.get_default().window_closed.connect( reload );
-	}
-
-	private Wnck.Window get_current_window(){
-		Wnck.Window* win = null;
-		Wnck.WindowType window_type;
-		string behaviour = gsettings.get_string("behaviour");
-
-		switch(behaviour){
-			case "active-always":
-				win = Wnck.Screen.get_default().get_active_window();
-				if(win != null){
-					window_type = win->get_window_type();
-					if(window_type == Wnck.WindowType.DESKTOP || window_type == Wnck.WindowType.DOCK)
-						win = null;
-				}
-			break;
-			case "active-maximized":
-				win = Wnck.Screen.get_default().get_active_window();
-				if(win != null && !win->is_maximized())
-					win = null;
-			break;
-			case "topmost-maximized":
-				List<weak Wnck.Window> windows = Wnck.Screen.get_default().get_windows_stacked().copy();
-				windows.reverse();
-				foreach(Wnck.Window* w in windows) {
-					if(w->is_maximized() && !w->is_minimized()){
-						win = w;
-						break;
+			switch(behaviour){
+				case "active-always":
+					win = Wnck.Screen.get_default().get_active_window();
+					if(win != null){
+						window_type = win->get_window_type();
+						if(window_type == Wnck.WindowType.DESKTOP || window_type == Wnck.WindowType.DOCK)
+							win = null;
 					}
-				}
-			break;
-		}
+				break;
+				case "active-maximized":
+					win = Wnck.Screen.get_default().get_active_window();
+					if(win != null && !win->is_maximized())
+						win = null;
+				break;
+				case "topmost-maximized":
+					List<weak Wnck.Window> windows = Wnck.Screen.get_default().get_windows_stacked().copy();
+					windows.reverse();
+					foreach(Wnck.Window* w in windows) {
+						if(w->is_maximized() && !w->is_minimized()){
+							win = w;
+							break;
+						}
+					}
+				break;
+			}
 
-		return win;
+			return win;
+		}
 	}
 
 	private bool factory(MatePanel.Applet applet,string iid){
 		if(iid != "WindowMenuApplet")return false;
 
-		gsettings = new GLib.Settings("org.mate.window-applets.window-menu");
-
-		button = new WindowMenuButton();
-
-		change_behaviour();
-		change_orient(applet);
+		var windowMenu = new WindowMenu();
 
 		Gtk.Builder builder = new Gtk.Builder();
 
@@ -146,10 +145,10 @@ namespace WindowMenuApplet{
 		string menu = """<menuitem name="Settings" action="settings" />""";
 		menu += """<menuitem name="About" action="about" />""";
 
-		gsettings.bind("behaviour",builder.get_object("behaviour"),"active_id",SettingsBindFlags.DEFAULT);
-		gsettings.changed["behaviour"].connect( () => { change_behaviour(); reload(); } );
+		windowMenu.gsettings.bind("behaviour",builder.get_object("behaviour"),"active_id",SettingsBindFlags.DEFAULT);
+		windowMenu.gsettings.changed["behaviour"].connect( () => { windowMenu.change_behaviour(); windowMenu.reload(); } );
 
-		applet.add(button);
+		applet.add(windowMenu.button);
 		applet.setup_menu(menu,action_group);
 
 		settings.delete_event.connect( (event) => { settings.hide() ; return true ; } );
@@ -158,11 +157,15 @@ namespace WindowMenuApplet{
 		settings_action.activate.connect( () => { settings.present() ; } );
 		about_action.activate.connect( () => { about.present() ; } );
 
-		applet.change_orient.connect( () => { change_orient(applet) ; } );
+		applet.change_orient.connect( () => { windowMenu.change_orient(applet); windowMenu.reload(); } );
 
 		applet.show_all();
 
-		Wnck.Screen.get_default().active_window_changed.connect( reload );
+		Wnck.Screen.get_default().active_window_changed.connect( windowMenu.reload );
+
+		windowMenu.change_orient(applet);
+		windowMenu.change_behaviour();
+		windowMenu.reload();
 
 		return true;
 	}

--- a/window-title-applet/window-title-applet.vala
+++ b/window-title-applet/window-title-applet.vala
@@ -89,7 +89,7 @@ namespace WindowTitleApplet{
 				if(win->is_minimized())
 					continue;
 
-				if(!win->is_on_workspace(active_workspace))
+				if(!win->is_in_viewport(active_workspace))
 					continue;
 
 				if(monitor != get_monitor_at_window(win))


### PR DESCRIPTION
The diffs for the first two commits are a bit of a mess since there was a large indentation change. I suggest looking at it with the "Ignore whitespace changes" option located in the little gear. But basically all I did was create a class and put all functions as methods. This was needed so we could have multiple instances of the same applet in a multi-monitor scenario.

The feature itself is in the third commit.

Again, I don't know much about the internal workings, so please let me know if there's a better way to achieve what I did.

~~The only issue I could not fix, is multiple workspace support when using Compiz. For some reason `Wnck.Screen.get_active_workspace` always returns "Workspace 1" no matter which workspace is active, and so does `Wnck.Window.get_workspace` for any window in any workspace. Any idea why? In Marco it works just fine.~~ Already figured it out.