### PR TITLE
Fix for blurry icons

### DIFF
--- a/window-buttons-applet/window-button.vala
+++ b/window-buttons-applet/window-button.vala
@@ -114,8 +114,8 @@ namespace WindowWidgets{
 			}
 
 			if(icon != null){
-				icon = icon.scale_simple(_icon_size, _icon_size, Gdk.InterpType.HYPER);
-				button_image.set_from_pixbuf(icon);
+				Cairo.Surface surface = Gdk.cairo_surface_create_from_pixbuf(icon, this.get_scale_factor(), null);
+				button_image.set_from_surface(surface);
 			}
 
 		}

--- a/window-buttons-applet/window-buttons-applet.vala
+++ b/window-buttons-applet/window-buttons-applet.vala
@@ -23,17 +23,19 @@ namespace WindowButtonsApplet{
 		protected WindowButton MAXIMIZE = new WindowButton(WindowButtonType.MAXIMIZE);
 
 		protected EnabledButtons enabled_buttons = EnabledButtons();
+		protected int icon_size;
 
 		private Gtk.StyleContext* applet_style_context;
 
 		// Constructor
 
-		public ButtonsApplet(Gtk.Orientation orient, Gtk.StyleContext* applet_style_context){
+		public ButtonsApplet(Gtk.Orientation orient, MatePanel.Applet applet){
 			Object(orientation: orient);
 
 			this.set_homogeneous(true);
 
-			this.applet_style_context = applet_style_context;
+			this.applet_style_context = applet.get_style_context();
+			this.set_size(applet.get_size());
 
 			this.change_layout();
 			this.change_theme();
@@ -41,8 +43,9 @@ namespace WindowButtonsApplet{
 			this.change_behaviour();
 
 			this.marco_gsettings.changed["theme"].connect(this.change_theme);
-			this.gsettings.changed["spacing"].connect(this.change_spacing);
 			this.marco_gsettings.changed["button_layout"].connect(this.change_layout);
+			this.gsettings.changed["spacing"].connect(this.change_spacing);
+			this.gsettings.changed["padding"].connect( (key) => { this.change_size(applet.get_size()); } );
 
 			Wnck.Screen.get_default().active_window_changed.connect(this.reload);
 
@@ -157,38 +160,33 @@ namespace WindowButtonsApplet{
 
 			Gdk.RGBA fg_color = applet_style_context->get_color(Gtk.StateFlags.ACTIVE);
 
-			WindowButtonsTheme theme = new WindowButtonsTheme(theme_name, fg_color);
+			WindowButtonsTheme theme = new WindowButtonsTheme(theme_name, fg_color, this.icon_size, this.get_scale_factor());
 
 			CLOSE.theme = theme;
+			CLOSE.icon_size = this.icon_size;
 			if(enabled_buttons.close)
 				CLOSE.update(true);
 
 			MINIMIZE.theme = theme;
+			MINIMIZE.icon_size = this.icon_size;
 			if(enabled_buttons.minimize)
 				MINIMIZE.update(true);
 
 			MAXIMIZE.theme = theme;
+			MAXIMIZE.icon_size = this.icon_size;
 			if(enabled_buttons.maximize)
 				MAXIMIZE.update(true);
 
 		}
 
-		public void change_size(int size){
+		public void set_size(int size){
 			int padding = gsettings.get_int("padding");
-			size -= padding;
+			this.icon_size = size - padding;
+		}
 
-			CLOSE.icon_size = size;
-			if(this.enabled_buttons.close == true)
-				CLOSE.update();
-
-			MINIMIZE.icon_size = size;
-			if(this.enabled_buttons.minimize == true)
-				MINIMIZE.update();
-
-			MAXIMIZE.icon_size = size;
-			if(this.enabled_buttons.maximize == true)
-				MAXIMIZE.update();
-
+		public void change_size(int size){
+			this.set_size(size);
+			this.change_theme();
 		}
 
 		public void change_orient(int orient){
@@ -271,11 +269,10 @@ namespace WindowButtonsApplet{
 		Gtk.Window settings = builder.get_object("Settings") as Gtk.Window;
 		Gtk.Window about = builder.get_object("About") as Gtk.Window;
 
-		var widget_container = new ButtonsApplet(Gtk.Orientation.HORIZONTAL, applet.get_style_context());
+		var widget_container = new ButtonsApplet(Gtk.Orientation.HORIZONTAL, applet);
 
 		widget_container.show();
 		widget_container.change_orient(applet.get_orient());
-		widget_container.change_size(applet.get_size());
 
 		Gtk.ActionGroup action_group = new Gtk.ActionGroup("action_group");
 
@@ -296,8 +293,6 @@ namespace WindowButtonsApplet{
 
 		widget_container.gsettings.changed["use-marco-layout"].connect(widget_container.change_layout);
 		widget_container.gsettings.changed["buttons-layout"].connect(widget_container.change_layout);
-		widget_container.gsettings.changed["spacing"].connect( (key) => { widget_container.change_size(applet.get_size()); } );
-		widget_container.gsettings.changed["padding"].connect( (key) => { widget_container.change_size(applet.get_size()); } );
 		widget_container.gsettings.changed["behaviour"].connect( () => { widget_container.change_behaviour(); widget_container.reload(); } );
 		applet.setup_menu(menu,action_group);
 

--- a/window-buttons-applet/window-buttons-theme.vala
+++ b/window-buttons-applet/window-buttons-theme.vala
@@ -2,6 +2,8 @@ namespace WindowWidgets {
 	public class WindowButtonsTheme {
 
 		private string _theme_name;
+		private int _icon_size;
+		private int _scale_factor;
 		private Gdk.Pixbuf[,,] _pixbufs;
 		private string[] _extensions;
 		private string[] _prefixes;
@@ -9,7 +11,7 @@ namespace WindowWidgets {
 		private string[,] _state_names;
 		private string[,] _action_names;
 
-		public WindowButtonsTheme(string name, Gdk.RGBA fg_color){
+		public WindowButtonsTheme(string name, Gdk.RGBA fg_color, int icon_size, int scale_factor){
 			_pixbufs = new Gdk.Pixbuf[
 				IconType.TYPES,
 				IconState.STATES,
@@ -18,7 +20,10 @@ namespace WindowWidgets {
 
 			_theme_name = name;
 
-			_extensions = {"png", "svg"};
+			_icon_size = icon_size;
+			_scale_factor = scale_factor;
+
+			_extensions = {"svg", "png"};
 
 			_prefixes = {null, "button", "icon"};
 
@@ -121,7 +126,7 @@ namespace WindowWidgets {
 			string file_path = find_icon_filepath(paths, icon_names);
 			if( file_path != null ){
 				try {
-					return new Gdk.Pixbuf.from_file(file_path);
+					return new Gdk.Pixbuf.from_file_at_size(file_path, this._icon_size * this._scale_factor, this._icon_size * this._scale_factor);
 				} catch (GLib.Error e){
 					stdout.printf("Error: %s\n", e.message);
 				}

--- a/window-menu-applet/window-menu-button.vala
+++ b/window-menu-applet/window-menu-button.vala
@@ -39,11 +39,14 @@ namespace WindowWidgets{
 		public void	icon_set(){
 			if(_window != null){
 				_icon = _window.get_icon();
-				_icon = _icon.scale_simple(_icon_size,_icon_size,Gdk.InterpType.HYPER);
+				_icon = _icon.scale_simple(_icon_size * this.get_scale_factor(),_icon_size * this.get_scale_factor(), Gdk.InterpType.HYPER);
+
 				if(!_window.is_active()){
 					_icon.saturate_and_pixelate(_icon, 0, false);
 				}
-				button_image.set_from_pixbuf(_icon);
+
+				Cairo.Surface surface = Gdk.cairo_surface_create_from_pixbuf(_icon, this.get_scale_factor(), null);
+				button_image.set_from_surface(surface);
 			}
 			else {
 				button_image.clear();


### PR DESCRIPTION
This PR prevents blurriness in window-buttons-applet by prioritizing svg over png for icons. It also adds support for HiDPI. This should fix bug #24 

Also, window-menu-applet now shows a slightly sharper icon, but might still be blurry on taller panels, since the window icon returned by libwnck is a fixed size 32x32 pixbuf.